### PR TITLE
Implement HTTP Bearer auth with Amazon Cognito

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -1,5 +1,10 @@
 # ttg-server envs
+## .htpasswd file for HTTP Basic Auth
 HTPASSWD_FILE=tests/.htpasswd
+
+## Amazon Cognito credentials for HTTP Bearer Auth
+## AWS_COGNITO_POOL_ID=xxxxxxxxxxxxxxxxx
+## AWS_COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxx
 
 # postgres envs
 POSTGRES_PASSWORD=mypassword

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Please follow the [GitHub flow](https://docs.github.com/en/get-started/using-git
   - **Local:** [Postgres](https://www.postgresql.org/), [MinIO](https://min.io/)
 - **Authorization:**
   - [Passport.js](https://www.passportjs.org/)
-  - **Production:** TBD
+  - **Production:** [Amazon Cognito](https://aws.amazon.com/cognito/), [aws-jwt-verify](https://github.com/awslabs/aws-jwt-verify#readme), [passport-http-bearer](https://www.passportjs.org/packages/passport-http-bearer/)
   - **Local:** [http-auth](https://www.npmjs.com/package/http-auth), [http-auth-passport](https://www.npmjs.com/package/http-auth-passport)
 - **Testing:**
   - **Unit Testing:** [Jest](https://jestjs.io/), [Supertest](https://github.com/ladjs/supertest#readme)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ttg-server",
       "version": "0.0.1",
       "dependencies": {
+        "aws-jwt-verify": "^5.0.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "crypto": "^1.0.1",
@@ -18,6 +19,7 @@
         "http-auth": "^4.2.0",
         "http-auth-passport": "^1.0.7",
         "passport": "^0.7.0",
+        "passport-http-bearer": "^1.0.1",
         "pino-http": "^10.3.0",
         "stoppable": "^1.1.0"
       },
@@ -1936,6 +1938,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.0.0.tgz",
+      "integrity": "sha512-FQM5EYEm7AnVJ3oeTpvBZQm7hYnpI067Em1oopHBs7cCNAcw8Aw8NFbojFjkNXifsOzyYe1ks+bg7Q9fMsTZSA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/axios": {
@@ -5922,6 +5933,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-http-bearer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
+      "integrity": "sha512-SELQM+dOTuMigr9yu8Wo4Fm3ciFfkMq5h/ZQ8ffi4ELgZrX1xh9PlglqZdcUZ1upzJD/whVyt+YWF62s3U6Ipw==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/passport-strategy": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "supertest": "^7.0.0"
   },
   "dependencies": {
+    "aws-jwt-verify": "^5.0.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
@@ -47,6 +48,7 @@
     "http-auth": "^4.2.0",
     "http-auth-passport": "^1.0.7",
     "passport": "^0.7.0",
+    "passport-http-bearer": "^1.0.1",
     "pino-http": "^10.3.0",
     "stoppable": "^1.1.0"
   }

--- a/src/auth/cognito.js
+++ b/src/auth/cognito.js
@@ -1,0 +1,63 @@
+// Configure a JWT token strategy for Passport based on
+// Identity Token provided by Cognito. The token will be
+// parsed from the Authorization header (i.e., Bearer Token).
+
+const BearerStrategy = require("passport-http-bearer").Strategy;
+const { CognitoJwtVerifier } = require("aws-jwt-verify");
+
+const authorize = require("./auth-middleware");
+const logger = require("../logger");
+
+// We expect AWS_COGNITO_POOL_ID and AWS_COGNITO_CLIENT_ID to be defined.
+if (!(process.env.AWS_COGNITO_POOL_ID && process.env.AWS_COGNITO_CLIENT_ID)) {
+  throw new Error(
+    "missing expected env vars: AWS_COGNITO_POOL_ID, AWS_COGNITO_CLIENT_ID",
+  );
+}
+
+// Create a Cognito JWT Verifier, which will confirm that any JWT we
+// get from a user is valid and something we can trust. See:
+// https://github.com/awslabs/aws-jwt-verify#cognitojwtverifier-verify-parameters
+const jwtVerifier = CognitoJwtVerifier.create({
+  // These variables must be set in the .env
+  userPoolId: process.env.AWS_COGNITO_POOL_ID,
+  clientId: process.env.AWS_COGNITO_CLIENT_ID,
+  // We expect an Identity Token (vs. Access Token)
+  tokenUse: "id",
+});
+
+// Later we'll use other auth configurations, so it's important to log what's happening
+logger.info("Configured to use AWS Cognito for Authorization");
+
+// At startup, download and cache the public keys (JWKS) we need in order to
+// verify our Cognito JWTs, see https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-sets
+// You can try this yourself using:
+// curl https://cognito-idp.us-east-1.amazonaws.com/<user-pool-id>/.well-known/jwks.json
+jwtVerifier
+  .hydrate()
+  .then(() => {
+    logger.info("Cognito JWKS successfully cached");
+  })
+  .catch((err) => {
+    logger.error({ err }, "Unable to cache Cognito JWKS");
+  });
+
+module.exports.strategy = () =>
+  // For our Passport authentication strategy, we'll look for the Bearer Token
+  // in the Authorization header, then verify that with our Cognito JWT Verifier.
+  new BearerStrategy(async (token, done) => {
+    try {
+      // Verify this JWT
+      const user = await jwtVerifier.verify(token);
+      logger.debug({ user }, "Verified user token");
+
+      // Create a user, but only bother with their email. We could
+      // also do a lookup in a database, but we don't need it.
+      done(null, user.email);
+    } catch (err) {
+      logger.error({ err, token }, "Could not verify user token");
+      done(null, false);
+    }
+  });
+
+module.exports.authenticate = () => authorize("bearer");

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -1,5 +1,9 @@
+// Prefer Amazon Cognito
+if (process.env.AWS_COGNITO_POOL_ID && process.env.AWS_COGNITO_CLIENT_ID) {
+  module.exports = require("./cognito");
+}
 // Allow for an .htpasswd file to be used, but not in production
-if (process.env.HTPASSWD_FILE && process.NODE_ENV !== "production") {
+else if (process.env.HTPASSWD_FILE && process.NODE_ENV !== "production") {
   module.exports = require("./basic-auth");
 }
 // In all other cases, we need to stop now and fix our config


### PR DESCRIPTION
**Reference to Related Issue**

Fixes #44 

**Proposed Changes**

- [x] HTTP Bearer Auth with Amazon Cognito using passport-http-bearer and aws-jwt-verify
- [x] Add passport-http-bearer and aws-jwt-verify docs links
- [x] Add placeholder Cognito envs to .env.docker-compose
