### PR TITLE
Remove pgadmin from CI

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -4,7 +4,7 @@
 ## Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 ## See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://postgres:mypassword@localhost:5432/mydb?schema=public"
+DATABASE_URL="postgresql://postgres:mypassword@localhost:5432/postgres?schema=public"
 
 ## .htpasswd file for HTTP Basic Auth
 HTPASSWD_FILE=tests/.htpasswd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: npm install
 
       - name: Build Containers
-        run: docker compose up -d
+        run: docker compose -f docker-compose.ci.yml up -d
 
       - name: Wait for Services to be Healthy
         run: |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## Running
 
-### Docker Compose (Recommended)
+### Docker Compose
 
 This will run the server with a Docker Compose stack including Postgres, pgAdmin, and MinIO. It will persist data in Docker volumes even after the services are stopped.
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,53 @@
+services:
+  ttg-server:
+    container_name: ttg-server
+    build: .
+    depends_on:
+      - postgres
+      - minio
+    ports:
+      - 8080:8080
+    env_file:
+      - .env.docker-compose
+    init: true
+
+  postgres:
+    container_name: ttg-postgres
+    image: postgres:17.2-alpine3.21
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/initdb:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.docker-compose
+    init: true
+
+  minio:
+    container_name: ttg-minio
+    image: minio/minio
+    command: server --console-address ":9001" /data
+    ports:
+      # The minio API endpoint
+      - "9000:9000"
+      # The minio web console endpoint
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - .env.docker-compose
+    init: true
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   pgadmin:
     container_name: ttg-pgadmin
     image: dpage/pgadmin4:8.14
+    depends_on: postgres
     ports:
       - 5050:80
     volumes:


### PR DESCRIPTION
**Reference to Related Issue**

Fixes #113 

**Proposed Changes**

- [x] Create `docker-compose.ci.yml` without pgadmin
- [x] Use `docker-compose.ci.yml` in CI
- [x] Remove "recommended" next to Docker Compose in README
