### PR TITLE
fix(assets): use "status: ok" in response body

### DIFF
--- a/src/routes/api/assets/post.js
+++ b/src/routes/api/assets/post.js
@@ -1,6 +1,7 @@
 const asset = require("../../../model/asset");
 const logger = require("../../../logger");
 const generate = require("../../../generator");
+const { createSuccessResponse } = require("../../../response");
 
 /**
  * Generate and save an asset
@@ -48,7 +49,6 @@ module.exports = async (req, res, next) => {
     return next(error);
   }
 
-  // Return asset metadata
   const locationURL = new URL(
     `/v1/assets/${newAsset.uuid}`,
     process.env?.API_URL || `https://${req.headers?.host}`,
@@ -59,5 +59,9 @@ module.exports = async (req, res, next) => {
     `constructed URL for Location header for new asset`,
   );
 
-  return res.status(201).set("Location", locationURL).json(newAsset);
+  // Return asset metadata
+  return res
+    .status(201)
+    .set("Location", locationURL)
+    .json(createSuccessResponse({ asset: newAsset }));
 };

--- a/tests/integration/assets-post.hurl
+++ b/tests/integration/assets-post.hurl
@@ -21,18 +21,19 @@ user1@email.com:password1
 
 HTTP/1.1 201
 [Captures]
-uuid: jsonpath "$.uuid"
+uuid: jsonpath "$.asset.uuid"
 [Asserts]
 header "Location" matches "^(http|https):\/\/localhost:8080\/v1\/assets\/[A-Za-z0-9_-]+$"
-jsonpath "$.id" isInteger
-jsonpath "$.uuid" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.creatorId" isInteger
-jsonpath "$.createdAt" isIsoDate
-jsonpath "$.updatedAt" isIsoDate
-jsonpath "$.isFeatured" isBoolean
-jsonpath "$.likes" isInteger
-jsonpath "$.type" matches "^character$|^location$|^quest$|^map$"
-jsonpath "$.name" isString
-jsonpath "$.description" isString
-jsonpath "$.imageUrl" matches "^http:\/\/(localhost|minio):9000\/ttg\/11d4c22e42c8f61feaba154683dea407b101cfd90987dda9e342843263ca420a\/{{uuid}}"
-jsonpath "$.imageUrlExpiry" isIsoDate
+jsonpath "$.status" == "ok"
+jsonpath "$.asset.id" isInteger
+jsonpath "$.asset.uuid" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.asset.creatorId" isInteger
+jsonpath "$.asset.createdAt" isIsoDate
+jsonpath "$.asset.updatedAt" isIsoDate
+jsonpath "$.asset.isFeatured" isBoolean
+jsonpath "$.asset.likes" isInteger
+jsonpath "$.asset.type" matches "^character$|^location$|^quest$|^map$"
+jsonpath "$.asset.name" isString
+jsonpath "$.asset.description" isString
+jsonpath "$.asset.imageUrl" matches "^http:\/\/(localhost|minio):9000\/ttg\/11d4c22e42c8f61feaba154683dea407b101cfd90987dda9e342843263ca420a\/{{uuid}}"
+jsonpath "$.asset.imageUrlExpiry" isIsoDate


### PR DESCRIPTION
**Reference to Related Issue**

N/A

**Proposed Changes**

- [x] Change POST /v1/assets response format. Add "status" property, move asset data into "asset" property. This makes it consistent with other endpoints.

```jsonc
{
  "status": "ok",
  "asset": {
    // ...
  }
}
```