### PR TITLE
Removing rate limiter for posting assets

### DIFF
--- a/src/routes/api/assets/index.js
+++ b/src/routes/api/assets/index.js
@@ -5,18 +5,10 @@ const express = require("express");
  */
 
 // Create a stricter rate limiter for POST /assets
-const { rateLimit } = require("express-rate-limit");
-
-const assetGenerationLimiter = rateLimit({
-  windowMs: 5 * 60 * 1000, // 5 minute window
-  limit: 10, // 10 requests per window
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 const router = express.Router();
 
-router.post(`/`, assetGenerationLimiter, require("./post"));
+router.post(`/`, require("./post"));
 
 router.get(`/`, require("./get"));
 

--- a/src/routes/api/assets/index.js
+++ b/src/routes/api/assets/index.js
@@ -4,8 +4,6 @@ const express = require("express");
  * The entry-point for /assets endpoints
  */
 
-// Create a stricter rate limiter for POST /assets
-
 const router = express.Router();
 
 router.post(`/`, require("./post"));


### PR DESCRIPTION
# Removing rate limiter 

## Description
removing the post rate limiter for assets due to it hindering the testing for DELETE /v1/assets/:id 

## Related Issues
#68 