### PR TITLE
asset GET routes now respond with list of users that liked asset

### DIFF
--- a/src/routes/api/assets/getById.js
+++ b/src/routes/api/assets/getById.js
@@ -2,6 +2,7 @@ const logger = require("../../../logger");
 const { z } = require("zod");
 const { PrismaClientKnownRequestError } = require("@prisma/client").Prisma;
 const asset = require("../../../model/asset");
+const prisma = require("../../../model/data/prismaClient");
 const { createSuccessResponse } = require("../../../response");
 
 /**
@@ -25,6 +26,15 @@ module.exports = async (req, res, next) => {
   let foundAsset;
   try {
     foundAsset = await asset.get(req.params.assetId);
+    // Fetch likes details for this asset
+    const likes = await prisma.userAssetLike.findMany({
+      where: { asset_id: foundAsset.id },
+      include: { User: { select: { hashedEmail: true } } },
+    });
+    // Update like info: count and list of hashed emails
+    foundAsset.likes = likes.length;
+    foundAsset.likedBy = likes.map((like) => like.User.hashedEmail);
+
     logger.debug({ foundAsset }, "Retrieved asset");
   } catch (error) {
     logger.error({ error }, "Error fetching asset");

--- a/src/routes/api/assets/patchById.js
+++ b/src/routes/api/assets/patchById.js
@@ -107,7 +107,6 @@ module.exports = async (req, res, next) => {
             },
           },
         });
-        asset.likes--;
       } else {
         await prisma.userAssetLike.create({
           data: {
@@ -115,13 +114,16 @@ module.exports = async (req, res, next) => {
             asset_id: asset.id,
           },
         });
-        asset.likes++;
       }
 
       // Update likes count in Asset table
+      const newLikeCount = await prisma.userAssetLike.count({
+        where: { asset_id: asset.id },
+      });
+
       const updatedAsset = await prisma.asset.update({
         where: { id: asset.id },
-        data: { likes: asset.likes, updatedAt: new Date() },
+        data: { likes: newLikeCount, updatedAt: new Date() },
         select: { likes: true },
       });
 


### PR DESCRIPTION
### Description 
GET /v1/assets and GET /v1/assets/:id now responds with an array of users who've liked the asset

### Changes 
* GET routes updated so now they respond with users that have liked the asset
* PATCH route updated to use bridge table for like counts

### Related Issues
Fixes #193 

