### PR TITLE
Bring OpenAPI description and Hurl tests in line with each other

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14528,100 +14528,136 @@
                                     class="collapser"
                                     aria-label="collapse"
                                   ></button
-                                  ><span class="token punctuation">[</span
+                                  ><span class="token punctuation">{</span
                                   ><span class="ellipsis"></span>
-                                  <ul class="array collapsible">
+                                  <ul class="obj collapsible">
                                     <li>
                                       <div class="hoverable">
+                                        <span class="property token string"
+                                          >"comments"</span
+                                        >:
                                         <button
                                           class="collapser"
                                           aria-label="collapse"
                                         ></button
-                                        ><span class="token punctuation">{</span
+                                        ><span class="token punctuation">[</span
                                         ><span class="ellipsis"></span>
-                                        <ul class="obj collapsible">
+                                        <ul class="array collapsible">
                                           <li>
                                             <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"userId"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;2c4a230c-5085-4924-a3e1-25fb4fc5965b&quot;</span
+                                              <button
+                                                class="collapser"
+                                                aria-label="expand"
+                                              ></button
                                               ><span class="token punctuation"
-                                                >,</span
-                                              >
-                                            </div>
-                                          </li>
-                                          <li>
-                                            <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"displayName"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;string&quot;</span
-                                              ><span class="token punctuation"
-                                                >,</span
-                                              >
-                                            </div>
-                                          </li>
-                                          <li>
-                                            <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"commentId"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;ee0469af-2fa1-4b7e-b5f1-8e711a95821b&quot;</span
-                                              ><span class="token punctuation"
-                                                >,</span
-                                              >
-                                            </div>
-                                          </li>
-                                          <li>
-                                            <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"body"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;string&quot;</span
-                                              ><span class="token punctuation"
-                                                >,</span
-                                              >
-                                            </div>
-                                          </li>
-                                          <li>
-                                            <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"createdAt"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;2019-08-24T14:15:22Z&quot;</span
-                                              ><span class="token punctuation"
-                                                >,</span
-                                              >
-                                            </div>
-                                          </li>
-                                          <li>
-                                            <div class="hoverable collapsed">
-                                              <span
-                                                class="property token string"
-                                                >"updatedAt"</span
-                                              >:
-                                              <span class="token string"
-                                                >&quot;2019-08-24T14:15:22Z&quot;</span
+                                                >{</span
+                                              ><span class="ellipsis"></span>
+                                              <ul class="obj collapsible">
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"userId"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;2c4a230c-5085-4924-a3e1-25fb4fc5965b&quot;</span
+                                                    ><span
+                                                      class="token punctuation"
+                                                      >,</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"displayName"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;string&quot;</span
+                                                    ><span
+                                                      class="token punctuation"
+                                                      >,</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"commentId"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;ee0469af-2fa1-4b7e-b5f1-8e711a95821b&quot;</span
+                                                    ><span
+                                                      class="token punctuation"
+                                                      >,</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"body"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;string&quot;</span
+                                                    ><span
+                                                      class="token punctuation"
+                                                      >,</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"createdAt"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;2019-08-24T14:15:22Z&quot;</span
+                                                    ><span
+                                                      class="token punctuation"
+                                                      >,</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                                <li>
+                                                  <div
+                                                    class="hoverable collapsed"
+                                                  >
+                                                    <span
+                                                      class="property token string"
+                                                      >"updatedAt"</span
+                                                    >:
+                                                    <span class="token string"
+                                                      >&quot;2019-08-24T14:15:22Z&quot;</span
+                                                    >
+                                                  </div>
+                                                </li>
+                                              </ul>
+                                              <span class="token punctuation"
+                                                >}</span
                                               >
                                             </div>
                                           </li>
                                         </ul>
-                                        <span class="token punctuation">}</span>
+                                        <span class="token punctuation">]</span>
                                       </div>
                                     </li>
                                   </ul>
-                                  <span class="token punctuation">]</span></code
+                                  <span class="token punctuation">}</span></code
                                 >
                               </div>
                             </div>
@@ -16589,8 +16625,15 @@
                   content: {
                     "application/json": {
                       schema: {
-                        type: "array",
-                        items: { $ref: "#/components/schemas/comment" },
+                        type: "object",
+                        required: ["comments"],
+                        additionalProperties: false,
+                        properties: {
+                          comments: {
+                            type: "array",
+                            items: { $ref: "#/components/schemas/comment" },
+                          },
+                        },
                       },
                     },
                   },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -662,9 +662,14 @@ components:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/comment"
+            type: object
+            required: ["comments"]
+            additionalProperties: false
+            properties:
+              comments:
+                type: array
+                items:
+                  $ref: "#/components/schemas/comment"
     CollectionDetails:
       description: OK
       content:

--- a/tests/integration/stable/assets/get-by-id.hurl
+++ b/tests/integration/stable/assets/get-by-id.hurl
@@ -7,6 +7,8 @@ HTTP 403
 GET {{host}}/v1/assets/{{user1_public_asset_id}}
 HTTP 200
 [Asserts]
+jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.displayName" isString
 jsonpath "$.assetId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.name" isString
 jsonpath "$.description" isString

--- a/tests/integration/stable/assets/get-comments.hurl
+++ b/tests/integration/stable/assets/get-comments.hurl
@@ -37,3 +37,5 @@ DELETE {{host}}/v1/comments/{{comment_id}}
 [BasicAuth]
 user1@email.com:password1
 HTTP 204
+
+# TODO: test query parameters

--- a/tests/integration/stable/collections/add-and-remove-assets.hurl
+++ b/tests/integration/stable/collections/add-and-remove-assets.hurl
@@ -35,10 +35,10 @@ jsonpath "$.name" isString
 jsonpath "$.description" isString
 jsonpath "$.assetCount" isInteger
 jsonpath "$.assets" isCollection
-jsonpath "$.fragments[?(@.assetId == '{{user1_public_asset_id}}')].assetId" exists
-jsonpath "$.fragments[?(@.assetId == '{{user1_unlisted_asset_id}}')].assetId" exists
-jsonpath "$.fragments[?(@.assetId == '{{user1_private_asset_id}}')].assetId" exists
-jsonpath "$.fragments[?(@.assetId == '{{user2_public_asset_id}}')].assetId" exists
+jsonpath "$.assets[?(@.assetId == '{{user1_public_asset_id}}')].assetId" exists
+jsonpath "$.assets[?(@.assetId == '{{user1_unlisted_asset_id}}')].assetId" exists
+jsonpath "$.assets[?(@.assetId == '{{user1_private_asset_id}}')].assetId" exists
+jsonpath "$.assets[?(@.assetId == '{{user2_public_asset_id}}')].assetId" exists
 
 POST {{host}}/v1/collections/{{collection_id}}/assets
 Content-Type: application/json

--- a/tests/integration/stable/collections/add-and-remove-assets.hurl
+++ b/tests/integration/stable/collections/add-and-remove-assets.hurl
@@ -26,8 +26,8 @@ user1@email.com:password1
 HTTP 200
 [Asserts]
 jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.displayName" isString
+jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.createdAt" isIsoDate
 jsonpath "$.updatedAt" isIsoDate
 jsonpath "$.visibility" matches "^public$|^private$|^unlisted$"
@@ -35,6 +35,10 @@ jsonpath "$.name" isString
 jsonpath "$.description" isString
 jsonpath "$.assetCount" isInteger
 jsonpath "$.assets" isCollection
+jsonpath "$.fragments[?(@.assetId == '{{user1_public_asset_id}}')].assetId" exists
+jsonpath "$.fragments[?(@.assetId == '{{user1_unlisted_asset_id}}')].assetId" exists
+jsonpath "$.fragments[?(@.assetId == '{{user1_private_asset_id}}')].assetId" exists
+jsonpath "$.fragments[?(@.assetId == '{{user2_public_asset_id}}')].assetId" exists
 
 POST {{host}}/v1/collections/{{collection_id}}/assets
 Content-Type: application/json
@@ -53,10 +57,17 @@ user1@email.com:password1
   "assetIds": ["{{user1_public_asset_id}}", "{{user1_unlisted_asset_id}}", "{{user1_private_asset_id}}", "{{user2_public_asset_id}}"]
 }
 HTTP 200
-
-GET {{host}}/v1/collections/{{collection_id}}
-HTTP 200
 [Asserts]
+jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.displayName" isString
+jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.createdAt" isIsoDate
+jsonpath "$.updatedAt" isIsoDate
+jsonpath "$.visibility" matches "^public$|^private$|^unlisted$"
+jsonpath "$.name" isString
+jsonpath "$.description" isString
+jsonpath "$.assetCount" isInteger
+jsonpath "$.assets" isCollection
 jsonpath "$.assetCount" == 0
 jsonpath "$.assets" isEmpty
 

--- a/tests/integration/stable/collections/get-by-id.hurl
+++ b/tests/integration/stable/collections/get-by-id.hurl
@@ -5,8 +5,8 @@ GET {{host}}/v1/collections/{{user1_collection_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.displayName" isString
+jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.createdAt" isIsoDate
 jsonpath "$.updatedAt" isIsoDate
 jsonpath "$.visibility" matches "^public$|^private$|^unlisted$"

--- a/tests/integration/stable/collections/get.hurl
+++ b/tests/integration/stable/collections/get.hurl
@@ -3,8 +3,8 @@ HTTP 200
 [Asserts]
 jsonpath "$.collections" isCollection
 jsonpath "$.collections[0].userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.collections[0].collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.collections[0].displayName" isString
+jsonpath "$.collections[0].collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.collections[0].createdAt" isIsoDate
 jsonpath "$.collections[0].updatedAt" isIsoDate
 jsonpath "$.collections[0].visibility" matches "^public$|^private$|^unlisted$"

--- a/tests/integration/stable/collections/patch.hurl
+++ b/tests/integration/stable/collections/patch.hurl
@@ -31,8 +31,8 @@ file,collection-update.json;
 HTTP 200
 [Asserts]
 jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.displayName" isString
+jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.createdAt" isIsoDate
 jsonpath "$.updatedAt" isIsoDate
 jsonpath "$.visibility" matches "^public$|^private$|^unlisted$"

--- a/tests/integration/stable/collections/post.hurl
+++ b/tests/integration/stable/collections/post.hurl
@@ -9,8 +9,8 @@ file,collection.json;
 HTTP 201
 [Asserts]
 jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.displayName" isString
+jsonpath "$.collectionId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.createdAt" isIsoDate
 jsonpath "$.updatedAt" isIsoDate
 jsonpath "$.visibility" matches "^public$|^private$|^unlisted$"

--- a/tests/integration/stable/comment/patch.hurl
+++ b/tests/integration/stable/comment/patch.hurl
@@ -42,7 +42,7 @@ Content-Type: application/json
 user1@email.com:password1
 file,comment.json;
 HTTP 200
-[Assets]
+[Asserts]
 jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 jsonpath "$.displayName" isString
 jsonpath "$.commentId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"

--- a/tests/integration/stable/comment/patch.hurl
+++ b/tests/integration/stable/comment/patch.hurl
@@ -42,3 +42,10 @@ Content-Type: application/json
 user1@email.com:password1
 file,comment.json;
 HTTP 200
+[Assets]
+jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.displayName" isString
+jsonpath "$.commentId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.body" isString
+jsonpath "$.createdAt" isIsoDate
+jsonpath "$.updatedAt" isIsoDate

--- a/tests/integration/stable/users/post.hurl
+++ b/tests/integration/stable/users/post.hurl
@@ -13,3 +13,8 @@ HTTP *
 [Asserts]
 status >= 200
 status <= 201
+jsonpath "$.userId" matches "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+jsonpath "$.createdAt" isIsoDate
+jsonpath "$.updatedAt" isIsoDate
+jsonpath "$.displayName" isString
+jsonpath "$.bio" isString


### PR DESCRIPTION
**Reference to Related Issue**

Fixes #198

**Proposed Changes**

- [x] Add response body assertions for POST /users, PATCH /comments/{commentId}, GET /assets/{assetId}, POST /collections/{collectionId}/assets, POST /collections/{collectionId}/assets/remove
- [x] Change the OpenAPI description to wrap the comments array in the response from GET /assets/{assetId}/comments in an object
